### PR TITLE
[Style] Frontend - Adicionar fonte e cores base do Figma ao projeto

### DIFF
--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Poppins", system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
@@ -13,13 +15,18 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+bold {
+  font-weight: 700;
+  color: #0052B4;
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #0052B4;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #0052B4;
 }
 
 body {
@@ -47,7 +54,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #0052B4;
 }
 button:focus,
 button:focus-visible {

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -6,8 +6,8 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #1d1b20;
+  background-color: #FFFFFF;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
Este PR implementa as fontes e cores base do design no Figma,

- **Importação de fontes**: Adicionada a fonte **Poppins** do Google Fonts.
- **Estilização de elementos**:
  - Ajustes nas cores e estilos de links (`a`) e botões (`button`).
  - Adicionado hover com cores específicas para links e botões.

### Alterações realizadas:
- Atualização do seletor `:root` com cores e fontes do Figma.
- Ajustes no comportamento de hover para links e botões.
- Configuração de estilos para o tema claro, incluindo cores de fundo e texto.

### Testes:
- Verificado o comportamento das fontes e cores.
- Testado o hover e foco em links e botões para garantir consistência visual.